### PR TITLE
Only Run on Diffs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,19 @@ const PATTERN = /console\.(log|error|warn|info)/
 const GLOBAL_PATTERN = new RegExp(PATTERN.source, 'g')
 const JS_FILE = /\.(js|ts)x?$/i
 
+const findConsole = (content, whitelist) => {
+  let matches = content.match(GLOBAL_PATTERN)
+  if (!matches) return []
+
+  matches = matches.filter(match => {
+    const singleMatch = PATTERN.exec(match)
+    if (!singleMatch || singleMatch.length === 0) return false
+    return !whitelist.includes(singleMatch[1])
+  })
+
+  return matches
+}
+
 /**
  * Danger plugin to prevent merging code that still has `console.log`s inside it.
  */
@@ -12,28 +25,24 @@ export default async function noConsole(options = {}) {
       '[danger-plugin-no-console] whitelist option has to be an array.',
     )
 
-  const files = danger.git.modified_files
-    .concat(danger.git.created_files)
+  const diffs = danger.git.created_files
+    .concat(danger.git.modified_files)
     .filter(file => JS_FILE.test(file))
-  const contents = await Promise.all(
-    files.map(file =>
-      danger.github.utils.fileContents(file).then(content => ({
+    .map(file => {
+      return danger.git.diffForFile(file).then(diff => ({
         file,
-        content,
-      })),
-    ),
-  )
-
-  contents.forEach(({ file, content }) => {
-    let matches = content.match(GLOBAL_PATTERN)
-    if (!matches) return
-    matches = matches.filter(match => {
-      const singleMatch = PATTERN.exec(match)
-      if (!singleMatch || singleMatch.length === 0) return false
-      return !whitelist.includes(singleMatch[1])
+        diff,
+      }))
     })
-    if (matches.length === 0) return
 
-    fail(`${matches.length} console statement(s) left in ${file}.`)
-  })
+  const additions = await Promise.all(diffs)
+
+  additions
+    .filter(({ diff }) => !!diff)
+    .forEach(({ file, diff }) => {
+      const matches = findConsole(diff.added, whitelist)
+      if (matches.length === 0) return
+
+      fail(`${matches.length} console statement(s) added in ${file}.`)
+    })
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -17,6 +17,10 @@ global.danger = {
   git: {
     modified_files: [fileNames[0], fileNames[1]],
     created_files: [fileNames[2], fileNames[3]],
+    diffForFile: file =>
+      Promise.resolve({
+        added: files[file],
+      }),
   },
   github: {
     utils: {


### PR DESCRIPTION
This PR updates the plugin to only run against actual diffs.  Without this change, making a change to a file that previously contained a `console` statement triggered a false positive.

While this is still not perfect, as it will likely throw for things like whitespace/refactors, I think it is still a preferable experience.  

I wasn't sure how to handle versioning as this is likely a breaking change.  Let me know what you think!