### PR TITLE
feat(options): Added callback option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,14 +15,23 @@ const findConsole = (content, whitelist) => {
   return matches
 }
 
+const defaultCallback = (file, matches) =>
+  fail(`${matches.length} console statement(s) added in ${file}.`)
+
 /**
  * Danger plugin to prevent merging code that still has `console.log`s inside it.
  */
 export default async function noConsole(options = {}) {
   const whitelist = options.whitelist || []
+  const callback = options.callback || defaultCallback
   if (!Array.isArray(whitelist))
     throw new Error(
       '[danger-plugin-no-console] whitelist option has to be an array.',
+    )
+
+  if (typeof callback !== 'function')
+    throw new Error(
+      '[danger-plugin-no-console] callback option has to be an function.',
     )
 
   const diffs = danger.git.created_files
@@ -43,6 +52,6 @@ export default async function noConsole(options = {}) {
       const matches = findConsole(diff.added, whitelist)
       if (matches.length === 0) return
 
-      fail(`${matches.length} console statement(s) added in ${file}.`)
+      callback(file, matches)
     })
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -54,6 +54,14 @@ describe('noConsole()', () => {
   it('should handle multiple console statements in a file', async () => {
     await noConsole({ whitelist: ['error', 'warn', 'log'] })
     expect(global.fail).toHaveBeenCalledTimes(1)
-    expect(global.fail.mock.calls[0][0].startsWith(2))
+    expect(global.fail.mock.calls[0][0].startsWith(10))
+  })
+
+  it('should call the given callback with the collected result', async () => {
+    const callback = jest.fn()
+    await noConsole({ callback })
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(callback.mock.calls[0][1]).toEqual(['console.error'])
+    expect(callback.mock.calls[0][0]).toEqual('src/error.js')
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,1 @@
-export default function noConsole(options?: { whitelist: string[] }): void
+export default function noConsole(options?: { whitelist?: string[], callback?: (file: string, matches: string[]) => {} }): void


### PR DESCRIPTION
Thank you for this awesome plugin! We wanted to be able to alter the error message to include an internal error code. This PR adds such functionality.

Example:
```js
const options = {callback: (file, matches) => warn(`custom message for ${file}`)}
```
This way it is also possible to `warn` instead or `fail` when needed.